### PR TITLE
Updated homebrew-php

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The `php-cgi` binary can be installed via Homebrew by tapping the
 
 ```shell
 brew tap homebrew/dupes
-brew tap josegonzalez/homebrew-php
+brew tap homebrew/homebrew-php
 brew install php54
 ```
 


### PR DESCRIPTION
josegonzalez/php was transferred as homebrew/php a [long time ago](https://github.com/Homebrew/homebrew-php/issues/1795).
